### PR TITLE
add cron-based removal of old logs in /var/log/syslog/

### DIFF
--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -9,6 +9,7 @@ RUN yum -y install \
   && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 \
   && yum -y install \
   bind-utils \
+  cronie \
   netcat \
   net-tools \
   nmap \
@@ -64,6 +65,7 @@ COPY inputs.conf /opt/splunkforwarder/etc/apps/search/local/inputs.conf
 
 COPY outputs.conf /opt/splunkforwarder/etc/system/local/outputs.conf
 
+COPY crontab /etc/cron.d/syslog-pruning
 
 EXPOSE 514/udp
 EXPOSE 601/tcp

--- a/main/crontab
+++ b/main/crontab
@@ -1,0 +1,15 @@
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+
+# For details see man 4 crontabs
+
+# Example of job definition:
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name  command to be executed
+0 0 * * * root find /var/log/syslog -type f -mtime +7 -exec rm {} \; >> /var/log/syslog-pruning.log 2>&1

--- a/main/supervisord.conf
+++ b/main/supervisord.conf
@@ -7,3 +7,6 @@ command=/usr/sbin/syslog-ng --foreground --no-caps --verbose --debug
 [program:splunk]
 command=/opt/splunkforwarder/config_and_start_splunk.sh
 
+[program:cron]
+command=/usr/sbin/crond -n -s
+


### PR DESCRIPTION
This PR keeps syslog-splunk from chewing up arbitrary amounts of disk space over time by removing old logfiles.