### PR TITLE
MISC-230 - fix cron syntax error

### DIFF
--- a/main/crontab
+++ b/main/crontab
@@ -13,4 +13,4 @@ MAILTO=root
 # |  |  |  |  |
 # *  *  *  *  * user-name  command to be executed
 0 0 * * * root /bin/prune_logs.sh
-0 5 * * * root /bin/compress_logs.sh
+5 0 * * * root /bin/compress_logs.sh


### PR DESCRIPTION
I had mixed up the minutes and hours columns.
This job should run 5 minutes after midnight, not 5am.