### PR TITLE
turn off `--debug` option

### DIFF
--- a/main/supervisord.conf
+++ b/main/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 logfile=/var/log/supervisord.log
 
 [program:syslogng]
-command=/usr/sbin/syslog-ng --foreground --verbose --debug --stderr
+command=/usr/sbin/syslog-ng --foreground --verbose --stderr
 stdout_logfile=/var/log/syslog-ng-stdout.log
 stderr_logfile=/var/log/syslog-ng-stderr.log
 


### PR DESCRIPTION
It is too noisy, and generates a message for each incoming and outgoing log message.
This is causing us to bump up against our splunk ingress limit.