### PR TITLE
Revert change syslog ng conf

### DIFF
--- a/main/Dockerfile
+++ b/main/Dockerfile
@@ -1,7 +1,6 @@
 FROM balabit/syslog-ng:3.14.1
 MAINTAINER dpt <hart-ds-dpt@uscm.org>
 
-# fluentd
 RUN apt-get update \
   && apt-get install --no-install-recommends --fix-missing -y -q \
   curl \

--- a/main/syslog-ng.conf
+++ b/main/syslog-ng.conf
@@ -51,3 +51,19 @@ filter f_not_palo_alto { not (
   filter(f_palo_alto)
   );
 };
+
+
+log {
+    source(s_network_tcp);
+    filter(heartbeat_filter);
+    filter(f_not_palo_alto);
+    destination(d_application);
+    # destination(d_datadog);
+};
+
+log {
+    source(s_internal);
+    filter(heartbeat_filter);
+    destination(d_syslogng_file);
+    # destination(d_datadog);
+};

--- a/main/syslog-ng.conf
+++ b/main/syslog-ng.conf
@@ -57,13 +57,11 @@ log {
     source(s_network_tcp);
     filter(heartbeat_filter);
     filter(f_not_palo_alto);
-    destination(d_application);
-    # destination(d_datadog);
+    flags(final);
 };
 
 log {
     source(s_internal);
     filter(heartbeat_filter);
-    destination(d_syslogng_file);
-    # destination(d_datadog);
+    flags(final);
 };


### PR DESCRIPTION
This PR corrects the previous commit by reverting part of its changes, to correct the issue with the container not passing health checks. It also removes destinations and adds flags(final) to the syslog-ng.conf so that log traffic no longer gets send to Elastic Search

Change Source: 
https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/53#TOPIC-956586